### PR TITLE
upgrade version of pyopenssl into 17.5.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 mock==2.0.0
-requests==2.13.0
+requests==2.25.1
 tox==2.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aniso8601==1.2.0
-Flask==0.12.1
-cryptography==2.1.4
-pyOpenSSL==17.0.0
-PyYAML==3.12
+Flask==1.0
+cryptography==3.2
+pyOpenSSL==17.5.0
+PyYAML==5.3.1
 six>=1.11.0
 


### PR DESCRIPTION
Jira for https://echogroup.atlassian.net/browse/TDO-171
to upgrade for open_api service 